### PR TITLE
This PR adds support for connecting to remote Frida servers that require token authentication, specifically targeting port 65000 for FIREPAD lamda

### DIFF
--- a/Intent-monitor/build.gradle
+++ b/Intent-monitor/build.gradle
@@ -2,20 +2,30 @@ plugins {
   id 'application'
   id 'org.openjfx.javafxplugin' version '0.1.0'
   id 'org.beryx.jlink' version '2.26.0'
+  id 'java'
 }
 
 repositories {
   mavenCentral()
 }
 
+// Set Java compatibility to 17
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
+// Configure the application plugin to handle JavaFX properly
+application {
+  mainClass = 'org.medusa.intentmonitor.MainScreen'
+  applicationDefaultJvmArgs = [
+    '--add-modules', 'javafx.controls,javafx.fxml,javafx.web'
+  ]
+}
+
 javafx {
   version = "21"
   modules = ['javafx.controls', 'javafx.fxml', 'javafx.web']
-}
-
-application {
-  mainModule = 'org.medusa.intentmonitor'
-  mainClass = 'org.medusa.intentmonitor.MainScreen'
 }
 
 description = 'Stheno: A tool for analyzing and manipulating intents in Android applications'
@@ -54,4 +64,45 @@ jlink {
 }
 dependencies {
   implementation 'org.json:json:20240303'
+}
+
+// Create an executable JAR with all dependencies
+jar {
+  manifest {
+    attributes(
+      'Main-Class': 'org.medusa.intentmonitor.MainScreen'
+    )
+  }
+  from {
+    configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+  }
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// Alternative: Create a fat JAR using shadow plugin approach
+task fatJar(type: Jar) {
+  manifest {
+    attributes 'Main-Class': 'org.medusa.intentmonitor.MainScreen'
+  }
+  archiveClassifier = 'fat'
+  from sourceSets.main.output
+  dependsOn configurations.runtimeClasspath
+  from {
+    configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }
+  }
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// Create a runnable JAR with JavaFX launcher
+task runnableJar(type: Jar) {
+  manifest {
+    attributes 'Main-Class': 'org.medusa.intentmonitor.MainScreen'
+  }
+  archiveClassifier = 'runnable'
+  from sourceSets.main.output
+  dependsOn configurations.runtimeClasspath
+  from {
+    configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }
+  }
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ Stheno can be used either as a standalone tool or in conjunction with [Medusa](h
    ```sh
    ./gradlew build
    ```
+
+3. **Run the Application:**
+   
+   **Option A: Using Gradle (Recommended)**
+   ```sh
+   ./gradlew run
+   ```
+   
+   **Option B: Using the JAR file**
+   ```sh
+   # Build the fat JAR with all dependencies
+   ./gradlew fatJar
+   
+   # Run the JAR (requires JavaFX to be installed)
+   java --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml,javafx.web -jar build/libs/Intent-monitor-fat.jar
+   ```
+   
+   **Option C: Using custom runtime (includes JavaFX)**
+   ```sh
+   # Create custom runtime with JavaFX included
+   ./gradlew jlink
+   
+   # Run the custom runtime
+   ./build/image/bin/Stheno
+   ```
+
 ### Using with Medusa:
 
 If you are using Stheno with Medusa, only step 2 is necessary:
@@ -45,12 +71,61 @@ If you are using Stheno with Medusa, only step 2 is necessary:
    ```sh
    ./gradlew build
    ```
+
+2. **Run the Application:**
+   Use any of the methods described in step 3 above.
 ---
 
 ## Basic Usage:
 
 1. Run the python script defining the target app that you want to monitor (e.g. `python3 stheno.py -t com.foo.bar`)
-2. Run the monitor and got to menu->start to start monitoring the intents
+2. Run the monitor and go to menu->start to start monitoring the intents
+
+## Troubleshooting
+
+### JavaFX Issues
+If you encounter "JavaFX runtime components are missing" error:
+
+1. **Install JavaFX:**
+   ```sh
+   sudo apt update
+   sudo apt install openjfx libopenjfx-java
+   ```
+
+2. **Use the custom runtime (recommended):**
+   ```sh
+   ./gradlew jlink
+   ./build/image/bin/Stheno
+   ```
+
+### Module Resolution Issues
+If you encounter module resolution errors:
+
+1. **Use Gradle run (simplest):**
+   ```sh
+   ./gradlew run
+   ```
+
+2. **Or use the custom runtime:**
+   ```sh
+   ./gradlew jlink
+   ./build/image/bin/Stheno
+   ```
+
+### Build Issues
+If the build fails:
+
+1. **Clean and rebuild:**
+   ```sh
+   ./gradlew clean
+   ./gradlew build
+   ```
+
+2. **Check Java version:**
+   ```sh
+   java -version
+   ```
+   Ensure you're using Java 17 or higher.
 
 
 ## Contributing


### PR DESCRIPTION
### Stheno (`stheno.py`)
- **Enhanced device loading**: Supports remote Frida server connections with token authentication
- **Updated process enumeration**: Handles remote devices without relying on ADB commands
- **Added command line arguments**: `--remote-host` and `--remote-port` for specifying remote servers
- **Improved error handling**: Better process detection and connection management

### Intent-monitor (`build.gradle`)
- **Fixed Java compatibility**: Set Java 17 compatibility for modern JavaFX support
- **Added executable JAR support**: Created fat JAR with all dependencies
- **Enhanced build configuration**: Multiple run options including custom runtime with jlink
- **Updated README**: Comprehensive build and run instructions with troubleshooting